### PR TITLE
V0.0.8 beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tribute-utils",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Utility to interact with the rDAI smart-contracts.",
   "main": "./src/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tribute-utils",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Utility to interact with the rDAI smart-contracts.",
   "main": "./src/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tribute-utils",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Utility to interact with the rDAI smart-contracts.",
   "main": "./src/index.js",
   "repository": {

--- a/src/Tribute.js
+++ b/src/Tribute.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
-require("babel-polyfill");
-const ethers = require("ethers");
+require('babel-polyfill');
+const ethers = require('ethers');
 
 const { parseUnits, bigNumberify, formatUnits } = ethers.utils;
 
@@ -12,7 +12,7 @@ class Tribute {
     this.rDAI_DECIMALS = null;
     this.SELF_HAT_ID = null;
     this.userAddress = userAddress.toLowerCase();
-    this.PROPORTION_BASE = bigNumberify("0xFFFFFFFF");
+    this.PROPORTION_BASE = bigNumberify('0xFFFFFFFF');
   }
 
   async get_DAI_DECIMALS() {
@@ -72,10 +72,12 @@ class Tribute {
 
   async generate(amountToTransferString) {
     const DAI_DECIMALS = await this.get_DAI_DECIMALS();
-
+    let decimalSize = 0;
     // decimals length cannot be bigger than allowed DAI_DECIMALS
-    const decimalSize = amountToTransferString.split(".")[1].length;
-    if (decimalSize > DAI_DECIMALS) throw "Underflow Error";
+    if (typeof amountToTransferString.split('.')[1] !== 'undefined') {
+      decimalSize = amountToTransferString.split('.')[1].length;
+      if (decimalSize > DAI_DECIMALS) throw 'Underflow Error';
+    }
 
     // approve DAI
     const amountToTransfer_BN = parseUnits(
@@ -122,7 +124,7 @@ class Tribute {
 
     // Ensure the approval is complete before continuing
     // Else the tx will be rejected due to gas estimation failure
-    await approveTx.wait(1)
+    await approveTx.wait(1);
 
     await this.rDAIContract.mintWithNewHat(
       amountToTransfer_BN,
@@ -185,11 +187,11 @@ class Tribute {
     const SELF_HAT_ID = await this.get_SELF_HAT_ID();
     if (currentHat.hatID.eq(SELF_HAT_ID) || currentHat.hatID.isZero()) {
       // if balance < amountToFlow
-      if (balance_BN.lt(amountToFlow_BN)) throw "insuffient balance";
+      if (balance_BN.lt(amountToFlow_BN)) throw 'insuffient balance';
     }
 
     // validate if there are amountToFlows left in user portion
-    if (!(this.userAddress in recipientMap)) throw "insufficient balance left";
+    if (!(this.userAddress in recipientMap)) throw 'insufficient balance left';
 
     let userBal = recipientMap[this.userAddress]
       ? recipientMap[this.userAddress]
@@ -199,7 +201,7 @@ class Tribute {
       : ethers.constants.Zero;
     const sum = userBal.add(recipientBal);
 
-    if (sum.lt(amountToFlow_BN)) throw "insufficent balance left";
+    if (sum.lt(amountToFlow_BN)) throw 'insufficent balance left';
 
     // If we've reached this point we have enough to update, continue and update values
 
@@ -214,12 +216,12 @@ class Tribute {
     recipientMap = this._removeAddressesWithZeroFlow(recipientMap);
 
     // we need to reduce by additional powers. The difference between the number of 10's digits
-    const balanceWholeNumSize = formatUnits(userBal, DAI_DECIMALS).split(".")[0]
+    const balanceWholeNumSize = formatUnits(userBal, DAI_DECIMALS).split('.')[0]
       .length;
     const amountToFlowWholeNumSize = formatUnits(
       recipientBal,
       DAI_DECIMALS
-    ).split(".")[0].length;
+    ).split('.')[0].length;
     const tensDiff = balanceWholeNumSize - amountToFlowWholeNumSize;
 
     const newRecipients = Object.keys(recipientMap);
@@ -262,7 +264,7 @@ class Tribute {
     // validate if hat !exist
     const SELF_HAT_ID = await this.get_SELF_HAT_ID();
     if (currentHat.hatID.eq(SELF_HAT_ID) || currentHat.hatID.isZero())
-      throw "No flows to end";
+      throw 'No flows to end';
 
     // validate if there are amounts left in user portion
     if (!(addressToRemove.toLowerCase() in recipientMap))
@@ -282,12 +284,12 @@ class Tribute {
     recipientMap = this._removeAddressesWithZeroFlow(recipientMap);
 
     // we need to reduce by additional powers. The difference between the number of 10's digits
-    const balanceWholeNumSize = formatUnits(userBal, DAI_DECIMALS).split(".")[0]
+    const balanceWholeNumSize = formatUnits(userBal, DAI_DECIMALS).split('.')[0]
       .length;
     const amountToFlowWholeNumSize = formatUnits(
       recipientBal,
       DAI_DECIMALS
-    ).split(".")[0].length;
+    ).split('.')[0].length;
     const tensDiff = balanceWholeNumSize - amountToFlowWholeNumSize;
 
     const newRecipients = Object.keys(recipientMap);

--- a/src/Tribute.js
+++ b/src/Tribute.js
@@ -83,7 +83,7 @@ class Tribute {
       DAI_DECIMALS
     );
 
-    await this.DAIContract.approve(
+    const approveTx = await this.DAIContract.approve(
       this.rDAIContract.address,
       amountToTransfer_BN
     );
@@ -119,6 +119,10 @@ class Tribute {
     const newProportions = Object.values(recipientMap).map(value =>
       this._reduceToMaxPrecision(value).toNumber()
     );
+
+    // Ensure the approval is complete before continuing
+    // Else the tx will be rejected due to gas estimation failure
+    await approveTx.wait(1)
 
     await this.rDAIContract.mintWithNewHat(
       amountToTransfer_BN,

--- a/src/Tribute.js
+++ b/src/Tribute.js
@@ -159,8 +159,8 @@ class Tribute {
     const DAI_DECIMALS = await this.get_DAI_DECIMALS();
     let decimalSize = 0;
     // decimals length cannot be bigger than allowed DAI_DECIMALS
-    if (typeof amountToTransferString.split('.')[1] !== 'undefined') {
-      decimalSize = amountToTransferString.split('.')[1].length;
+    if (typeof amountToFlowString.split('.')[1] !== 'undefined') {
+      decimalSize = amountToFlowString.split('.')[1].length;
       if (decimalSize > DAI_DECIMALS) throw 'Underflow Error';
     }
 

--- a/src/Tribute.js
+++ b/src/Tribute.js
@@ -36,6 +36,16 @@ class Tribute {
     return this.SELF_HAT_ID;
   }
 
+  _calculateDecimalSize(number, DAI_DECIMALS) {
+    let decimalSize = 0;
+    // decimals length cannot be bigger than allowed DAI_DECIMALS
+    if (typeof number.split('.')[1] !== 'undefined') {
+      decimalSize = number.split('.')[1].length;
+      if (decimalSize > DAI_DECIMALS) throw 'Underflow Error';
+    }
+    return decimalSize;
+  }
+
   _calculateProportionWholeNumbers(proportions, balance_BN) {
     // NOTE: All math is done in expanded notion in base 10.
     // This is because there are no decimals
@@ -71,7 +81,12 @@ class Tribute {
   }
 
   async generate(amountToTransferString) {
-    const decimalSize = await this.get_decimal_size(amountToTransferString);
+    const DAI_DECIMALS = await this.get_DAI_DECIMALS();
+
+    const decimalSize = await this._calculateDecimalSize(
+      amountToTransferString,
+      DAI_DECIMALS
+    );
 
     // approve DAI
     const amountToTransfer_BN = parseUnits(
@@ -149,19 +164,13 @@ class Tribute {
     return { tx1, tx2 };
   }
 
-  async getDecimalSize(number) {
-    let decimalSize = 0;
-    const DAI_DECIMALS = await this.get_DAI_DECIMALS();
-    // decimals length cannot be bigger than allowed DAI_DECIMALS
-    if (typeof number.split('.')[1] !== 'undefined') {
-      decimalSize = number.split('.')[1].length;
-      if (decimalSize > DAI_DECIMALS) throw 'Underflow Error';
-    }
-    return decimalSize;
-  }
-
   async startFlow(recipientAddress, amountToFlowString) {
-    const decimalSize = await this.get_decimal_size(amountToFlowString);
+    const DAI_DECIMALS = await this.get_DAI_DECIMALS();
+
+    const decimalSize = this._calculateDecimalSize(
+      amountToFlowString,
+      DAI_DECIMALS
+    );
 
     const amountToFlow_BN = parseUnits(amountToFlowString, DAI_DECIMALS);
 

--- a/src/Tribute.js
+++ b/src/Tribute.js
@@ -71,13 +71,7 @@ class Tribute {
   }
 
   async generate(amountToTransferString) {
-    const DAI_DECIMALS = await this.get_DAI_DECIMALS();
-    let decimalSize = 0;
-    // decimals length cannot be bigger than allowed DAI_DECIMALS
-    if (typeof amountToTransferString.split('.')[1] !== 'undefined') {
-      decimalSize = amountToTransferString.split('.')[1].length;
-      if (decimalSize > DAI_DECIMALS) throw 'Underflow Error';
-    }
+    const decimalSize = await this.get_decimal_size(amountToTransferString);
 
     // approve DAI
     const amountToTransfer_BN = parseUnits(
@@ -155,14 +149,19 @@ class Tribute {
     return { tx1, tx2 };
   }
 
-  async startFlow(recipientAddress, amountToFlowString) {
-    const DAI_DECIMALS = await this.get_DAI_DECIMALS();
+  async getDecimalSize(number) {
     let decimalSize = 0;
+    const DAI_DECIMALS = await this.get_DAI_DECIMALS();
     // decimals length cannot be bigger than allowed DAI_DECIMALS
-    if (typeof amountToFlowString.split('.')[1] !== 'undefined') {
-      decimalSize = amountToFlowString.split('.')[1].length;
+    if (typeof number.split('.')[1] !== 'undefined') {
+      decimalSize = number.split('.')[1].length;
       if (decimalSize > DAI_DECIMALS) throw 'Underflow Error';
     }
+    return decimalSize;
+  }
+
+  async startFlow(recipientAddress, amountToFlowString) {
+    const decimalSize = await this.get_decimal_size(amountToFlowString);
 
     const amountToFlow_BN = parseUnits(amountToFlowString, DAI_DECIMALS);
 

--- a/src/Tribute.js
+++ b/src/Tribute.js
@@ -157,10 +157,12 @@ class Tribute {
 
   async startFlow(recipientAddress, amountToFlowString) {
     const DAI_DECIMALS = await this.get_DAI_DECIMALS();
-
+    let decimalSize = 0;
     // decimals length cannot be bigger than allowed DAI_DECIMALS
-    const decimalSize = amountToFlowString.split('.')[1].length;
-    if (decimalSize > DAI_DECIMALS) throw 'Underflow Error';
+    if (typeof amountToTransferString.split('.')[1] !== 'undefined') {
+      decimalSize = amountToTransferString.split('.')[1].length;
+      if (decimalSize > DAI_DECIMALS) throw 'Underflow Error';
+    }
 
     const amountToFlow_BN = parseUnits(amountToFlowString, DAI_DECIMALS);
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
-import Tribute from "./Tribute";
+import Tribute from './Tribute';
 
 export default Tribute;


### PR DESCRIPTION
## Changes

1. Old system for checking decimals threw error when using a whole number. I replaced this with the function `_calculateDecimalSize`
2. Added DAI balance to `getUserInfo`
3. Added `generateNew` which allows you to manually calculate the new proportions, instead of relying on Tribute.js. This function also passes back the `tx` object so the frontend can use the `tx.wait(1)` to know when each step is complete. Note: `tx.wait(1)` should be added to this function, as it is in item #4 below.
4. For `generate` I added `tx.wait(1)` to ensure the Approve call has completed. This is (yet another) reason why the second tx did not appear sometimes. The gas estimation check performed by metamask would fail, since the approval had not yet been completed.